### PR TITLE
Fix exception handling in AsyncDefaultAdmissionRequestMutator

### DIFF
--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionController.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionController.java
@@ -25,10 +25,9 @@ public class AdmissionController<T extends KubernetesResource> {
 
   public AdmissionReview handle(AdmissionReview admissionReview) {
     var response = admissionRequestHandler.handle(admissionReview.getRequest());
-    AdmissionReview responseAdmissionReview = new AdmissionReview();
+    var responseAdmissionReview = new AdmissionReview();
     responseAdmissionReview.setResponse(response);
     response.setUid(admissionReview.getRequest().getUid());
     return responseAdmissionReview;
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionRequestHandler.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionRequestHandler.java
@@ -6,5 +6,4 @@ import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 public interface AdmissionRequestHandler {
 
   AdmissionResponse handle(AdmissionRequest admissionRequest);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
@@ -17,6 +17,12 @@ public class AdmissionUtils {
 
   private AdmissionUtils() {}
 
+  public static AdmissionResponse allowedAdmissionResponse() {
+    var admissionResponse = new AdmissionResponse();
+    admissionResponse.setAllowed(true);
+    return admissionResponse;
+  }
+
   public static AdmissionResponse notAllowedExceptionToAdmissionResponse(
       NotAllowedException notAllowedException) {
     var admissionResponse = new AdmissionResponse();

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
@@ -19,7 +19,7 @@ public class AdmissionUtils {
 
   public static AdmissionResponse notAllowedExceptionToAdmissionResponse(
       NotAllowedException notAllowedException) {
-    AdmissionResponse admissionResponse = new AdmissionResponse();
+    var admissionResponse = new AdmissionResponse();
     admissionResponse.setAllowed(false);
     admissionResponse.setStatus(notAllowedException.getStatus());
     return admissionResponse;
@@ -33,17 +33,16 @@ public class AdmissionUtils {
 
   public static AdmissionResponse admissionResponseFromMutation(KubernetesResource originalResource,
       KubernetesResource mutatedResource) {
-    AdmissionResponse admissionResponse = new AdmissionResponse();
+    var admissionResponse = new AdmissionResponse();
     admissionResponse.setAllowed(true);
     admissionResponse.setPatchType(JSON_PATCH);
     var originalResNode = mapper.valueToTree(originalResource);
     var mutatedResNode = mapper.valueToTree(mutatedResource);
 
     var diff = JsonDiff.asJson(originalResNode, mutatedResNode);
-    String base64Diff =
+    var base64Diff =
         Base64.getEncoder().encodeToString(diff.toString().getBytes(StandardCharsets.UTF_8));
     admissionResponse.setPatch(base64Diff);
     return admissionResponse;
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionController.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionController.java
@@ -6,6 +6,7 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 import io.javaoperatorsdk.webhook.admission.mutation.AsyncDefaultAdmissionRequestMutator;
 import io.javaoperatorsdk.webhook.admission.mutation.AsyncMutator;
+import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
 import io.javaoperatorsdk.webhook.admission.validation.AsyncDefaultAdmissionRequestValidator;
 import io.javaoperatorsdk.webhook.admission.validation.Validator;
 
@@ -13,8 +14,12 @@ public class AsyncAdmissionController<T extends KubernetesResource> {
 
   private final AsyncAdmissionRequestHandler requestHandler;
 
-  public AsyncAdmissionController(AsyncMutator<T> mutator) {
+  public AsyncAdmissionController(Mutator<T> mutator) {
     this(new AsyncDefaultAdmissionRequestMutator<>(mutator));
+  }
+
+  public AsyncAdmissionController(AsyncMutator<T> asyncMutator) {
+    this(new AsyncDefaultAdmissionRequestMutator<>(asyncMutator));
   }
 
   public AsyncAdmissionController(Validator<T> validator) {

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionController.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionController.java
@@ -28,11 +28,10 @@ public class AsyncAdmissionController<T extends KubernetesResource> {
   public CompletionStage<AdmissionReview> handle(AdmissionReview admissionReview) {
     return requestHandler.handle(admissionReview.getRequest())
         .thenApply(r -> {
-          AdmissionReview responseAdmissionReview = new AdmissionReview();
+          var responseAdmissionReview = new AdmissionReview();
           responseAdmissionReview.setResponse(r);
           r.setUid(admissionReview.getRequest().getUid());
           return responseAdmissionReview;
         });
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionRequestHandler.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionRequestHandler.java
@@ -8,5 +8,4 @@ import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 public interface AsyncAdmissionRequestHandler {
 
   CompletionStage<AdmissionResponse> handle(AdmissionRequest admissionRequest);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/AsyncDefaultAdmissionRequestMutator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/AsyncDefaultAdmissionRequestMutator.java
@@ -33,7 +33,7 @@ public class AsyncDefaultAdmissionRequestMutator<T extends KubernetesResource>
 
   @Override
   public CompletionStage<AdmissionResponse> handle(AdmissionRequest admissionRequest) {
-    Operation operation = Operation.valueOf(admissionRequest.getOperation());
+    var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
     var clonedResource = cloner.clone(originalResource);
     CompletionStage<AdmissionResponse> admissionResponse;
@@ -47,5 +47,4 @@ public class AsyncDefaultAdmissionRequestMutator<T extends KubernetesResource>
     }
     return admissionResponse;
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/AsyncDefaultAdmissionRequestMutator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/AsyncDefaultAdmissionRequestMutator.java
@@ -32,6 +32,7 @@ public class AsyncDefaultAdmissionRequestMutator<T extends KubernetesResource>
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public CompletionStage<AdmissionResponse> handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/AsyncMutator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/AsyncMutator.java
@@ -9,5 +9,4 @@ import io.javaoperatorsdk.webhook.admission.Operation;
 public interface AsyncMutator<T extends KubernetesResource> {
 
   CompletionStage<T> mutate(T resource, Operation operation) throws NotAllowedException;
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/DefaultAdmissionRequestMutator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/DefaultAdmissionRequestMutator.java
@@ -29,6 +29,7 @@ public class DefaultAdmissionRequestMutator<T extends KubernetesResource>
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/DefaultAdmissionRequestMutator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/DefaultAdmissionRequestMutator.java
@@ -30,7 +30,7 @@ public class DefaultAdmissionRequestMutator<T extends KubernetesResource>
 
   @Override
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
-    Operation operation = Operation.valueOf(admissionRequest.getOperation());
+    var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
     var clonedResource = cloner.clone(originalResource);
     AdmissionResponse admissionResponse;
@@ -42,5 +42,4 @@ public class DefaultAdmissionRequestMutator<T extends KubernetesResource>
     }
     return admissionResponse;
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/Mutator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/mutation/Mutator.java
@@ -12,5 +12,4 @@ import io.javaoperatorsdk.webhook.admission.Operation;
 public interface Mutator<T extends KubernetesResource> {
 
   T mutate(T resource, Operation operation) throws NotAllowedException;
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/AsyncDefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/AsyncDefaultAdmissionRequestValidator.java
@@ -26,7 +26,7 @@ public class AsyncDefaultAdmissionRequestValidator<T extends KubernetesResource>
   @Override
   @SuppressWarnings("unchecked")
   public CompletionStage<AdmissionResponse> handle(AdmissionRequest admissionRequest) {
-    Operation operation = Operation.valueOf(admissionRequest.getOperation());
+    var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
 
     var asyncValidate =

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/AsyncDefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/AsyncDefaultAdmissionRequestValidator.java
@@ -7,12 +7,13 @@ import java.util.concurrent.CompletionStage;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
-import io.javaoperatorsdk.webhook.admission.AdmissionUtils;
 import io.javaoperatorsdk.webhook.admission.AsyncAdmissionRequestHandler;
 import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 
+import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.allowedAdmissionResponse;
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getTargetResource;
+import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.notAllowedExceptionToAdmissionResponse;
 
 public class AsyncDefaultAdmissionRequestValidator<T extends KubernetesResource>
     implements AsyncAdmissionRequestHandler {
@@ -28,7 +29,6 @@ public class AsyncDefaultAdmissionRequestValidator<T extends KubernetesResource>
   public CompletionStage<AdmissionResponse> handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
-
     var asyncValidate =
         CompletableFuture.runAsync(() -> validator.validate(originalResource, operation));
     return asyncValidate
@@ -36,20 +36,11 @@ public class AsyncDefaultAdmissionRequestValidator<T extends KubernetesResource>
         .exceptionally(e -> {
           if (e instanceof CompletionException) {
             if (e.getCause() instanceof NotAllowedException) {
-              return AdmissionUtils.notAllowedExceptionToAdmissionResponse(
-                  (NotAllowedException) e.getCause());
-            } else {
-              throw new IllegalStateException(e.getCause());
+              return notAllowedExceptionToAdmissionResponse((NotAllowedException) e.getCause());
             }
-          } else {
-            throw new IllegalStateException(e);
+            throw new IllegalStateException(e.getCause());
           }
+          throw new IllegalStateException(e);
         });
-  }
-
-  private AdmissionResponse allowedAdmissionResponse() {
-    AdmissionResponse admissionResponse = new AdmissionResponse();
-    admissionResponse.setAllowed(true);
-    return admissionResponse;
   }
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
@@ -20,6 +20,7 @@ public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
@@ -21,7 +21,7 @@ public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
 
   @Override
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
-    Operation operation = Operation.valueOf(admissionRequest.getOperation());
+    var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
     AdmissionResponse admissionResponse;
     try {

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
@@ -4,11 +4,12 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 import io.javaoperatorsdk.webhook.admission.AdmissionRequestHandler;
-import io.javaoperatorsdk.webhook.admission.AdmissionUtils;
 import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 
+import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.allowedAdmissionResponse;
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getTargetResource;
+import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.notAllowedExceptionToAdmissionResponse;
 
 public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
     implements AdmissionRequestHandler {
@@ -24,19 +25,11 @@ public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
-    AdmissionResponse admissionResponse;
     try {
       validator.validate(originalResource, operation);
-      admissionResponse = allowedAdmissionResponse();
+      return allowedAdmissionResponse();
     } catch (NotAllowedException e) {
-      admissionResponse = AdmissionUtils.notAllowedExceptionToAdmissionResponse(e);
+      return notAllowedExceptionToAdmissionResponse(e);
     }
-    return admissionResponse;
-  }
-
-  private AdmissionResponse allowedAdmissionResponse() {
-    AdmissionResponse admissionResponse = new AdmissionResponse();
-    admissionResponse.setAllowed(true);
-    return admissionResponse;
   }
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/Validator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/Validator.java
@@ -7,5 +7,4 @@ import io.javaoperatorsdk.webhook.admission.Operation;
 public interface Validator<T extends KubernetesResource> {
 
   void validate(T resource, Operation operation) throws NotAllowedException;
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/clone/Cloner.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/clone/Cloner.java
@@ -9,5 +9,4 @@ public interface Cloner<R> {
    * @return a deep copy of the given object if it isn't {@code null}, {@code null} otherwise
    */
   R clone(R object);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/clone/ObjectMapperCloner.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/clone/ObjectMapperCloner.java
@@ -8,6 +8,7 @@ public class ObjectMapperCloner<T> implements Cloner<T> {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
+  @SuppressWarnings("unchecked")
   public T clone(T object) {
     if (object == null) {
       return null;

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/AsyncConversionController.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/AsyncConversionController.java
@@ -65,7 +65,7 @@ public class AsyncConversionController implements AsyncConversionRequestHandler 
     });
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings("unchecked")
   private CompletableFuture<HasMetadata> mapObject(HasMetadata resource, String targetVersion) {
     var sourceVersion = Utils.versionOfApiVersion(resource.getApiVersion());
     var sourceToHubMapper = mappers.get(sourceVersion);

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/AsyncConversionRequestHandler.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/AsyncConversionRequestHandler.java
@@ -7,5 +7,4 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionReview;
 public interface AsyncConversionRequestHandler {
 
   CompletionStage<ConversionReview> handle(ConversionReview conversionReview);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/AsyncMapper.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/AsyncMapper.java
@@ -9,5 +9,4 @@ public interface AsyncMapper<R extends HasMetadata, HUB> {
   CompletionStage<HUB> toHub(R resource);
 
   CompletionStage<R> fromHub(HUB hub);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/Commons.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/Commons.java
@@ -17,7 +17,7 @@ public class Commons {
 
   public static ConversionReview createResponse(List<HasMetadata> convertedObjects,
       ConversionReview conversionReview) {
-    ConversionReview result = new ConversionReview();
+    var result = new ConversionReview();
     var response = new ConversionResponse();
     response.setResult(new Status());
     response.getResult().setStatus("Success");
@@ -30,7 +30,7 @@ public class Commons {
 
   public static ConversionReview createErrorResponse(Exception e,
       ConversionReview conversionReview) {
-    ConversionReview result = new ConversionReview();
+    var result = new ConversionReview();
     var response = new ConversionResponse();
     response.setUid(conversionReview.getRequest().getUid());
     response.setResult(new Status());
@@ -44,5 +44,4 @@ public class Commons {
     throw new MissingConversionMapperException(
         "Missing mapper from version: " + version);
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/ConversionController.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/ConversionController.java
@@ -45,13 +45,12 @@ public class ConversionController implements ConversionRequestHandler {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private List<HasMetadata> convertObjects(List<HasMetadata> objects, String targetVersion) {
     return objects.stream().map(r -> mapObject(r, targetVersion))
         .collect(Collectors.toList());
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
+  @SuppressWarnings("unchecked")
   private HasMetadata mapObject(HasMetadata resource, String targetVersion) {
     var sourceVersion = Utils.versionOfApiVersion(resource.getApiVersion());
     var sourceToHubMapper = mappers.get(sourceVersion);

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/ConversionController.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/ConversionController.java
@@ -11,7 +11,10 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionReview;
 
-import static io.javaoperatorsdk.webhook.conversion.Commons.*;
+import static io.javaoperatorsdk.webhook.conversion.Commons.MAPPER_ALREADY_REGISTERED_FOR_VERSION_MESSAGE;
+import static io.javaoperatorsdk.webhook.conversion.Commons.createErrorResponse;
+import static io.javaoperatorsdk.webhook.conversion.Commons.createResponse;
+import static io.javaoperatorsdk.webhook.conversion.Commons.throwMissingMapperForVersion;
 
 public class ConversionController implements ConversionRequestHandler {
 
@@ -21,7 +24,7 @@ public class ConversionController implements ConversionRequestHandler {
   private final Map<String, Mapper> mappers = new HashMap<>();
 
   public void registerMapper(Mapper<?, ?> mapper) {
-    String version = mapper.getClass().getDeclaredAnnotation(TargetVersion.class).value();
+    var version = mapper.getClass().getDeclaredAnnotation(TargetVersion.class).value();
     if (mappers.get(version) != null) {
       throw new IllegalStateException(MAPPER_ALREADY_REGISTERED_FOR_VERSION_MESSAGE + version);
     }
@@ -31,7 +34,7 @@ public class ConversionController implements ConversionRequestHandler {
   @Override
   public ConversionReview handle(ConversionReview conversionReview) {
     try {
-      List<HasMetadata> convertedObjects =
+      var convertedObjects =
           convertObjects(conversionReview.getRequest().getObjects().stream()
               .map(HasMetadata.class::cast).collect(Collectors.toList()),
               Utils.versionOfApiVersion(conversionReview.getRequest().getDesiredAPIVersion()));
@@ -50,7 +53,7 @@ public class ConversionController implements ConversionRequestHandler {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   private HasMetadata mapObject(HasMetadata resource, String targetVersion) {
-    String sourceVersion = Utils.versionOfApiVersion(resource.getApiVersion());
+    var sourceVersion = Utils.versionOfApiVersion(resource.getApiVersion());
     var sourceToHubMapper = mappers.get(sourceVersion);
     if (sourceToHubMapper == null) {
       throwMissingMapperForVersion(sourceVersion);
@@ -61,5 +64,4 @@ public class ConversionController implements ConversionRequestHandler {
     }
     return hubToTarget.fromHub(sourceToHubMapper.toHub(resource));
   }
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/ConversionRequestHandler.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/ConversionRequestHandler.java
@@ -5,5 +5,4 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionReview;
 public interface ConversionRequestHandler {
 
   ConversionReview handle(ConversionReview admissionRequest);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/Mapper.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/Mapper.java
@@ -7,5 +7,4 @@ public interface Mapper<R extends HasMetadata, HUB> {
   HUB toHub(R resource);
 
   R fromHub(HUB hub);
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/TargetVersion.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/TargetVersion.java
@@ -17,5 +17,4 @@ public @interface TargetVersion {
    * @return version
    **/
   String value();
-
 }

--- a/core/src/main/java/io/javaoperatorsdk/webhook/conversion/Utils.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/conversion/Utils.java
@@ -12,5 +12,4 @@ public class Utils {
     var lastDelimiter = apiVersion.lastIndexOf("/");
     return apiVersion.substring(lastDelimiter + 1);
   }
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/admission/AdmissionControllerTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/admission/AdmissionControllerTest.java
@@ -3,8 +3,11 @@ package io.javaoperatorsdk.webhook.admission;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
+import io.javaoperatorsdk.webhook.admission.validation.Validator;
 
-import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.*;
+import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.LABEL_TEST_VALUE;
+import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.MISSING_REQUIRED_LABEL;
 
 class AdmissionControllerTest {
 
@@ -12,23 +15,62 @@ class AdmissionControllerTest {
 
   @Test
   void validatesResource() {
-    AdmissionController<HasMetadata> admissionController =
-        new AdmissionController<>((resource, operation) -> {
-          if (resource.getMetadata().getLabels().get(AdmissionTestSupport.LABEL_KEY) == null) {
-            throw new NotAllowedException(MISSING_REQUIRED_LABEL);
-          }
-        });
+    var admissionController = new AdmissionController<HasMetadata>((resource, operation) -> {
+    });
     admissionTestSupport.validatesResource(admissionController::handle);
   }
 
   @Test
+  void validatesResource_whenNotAllowedException() {
+    var admissionController =
+        new AdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
+          throw new NotAllowedException(MISSING_REQUIRED_LABEL);
+        });
+    admissionTestSupport.notAllowedException(admissionController::handle);
+  }
+
+  @Test
+  void validatesResource_whenOtherException() {
+    var admissionController =
+        new AdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
+          throw new IllegalArgumentException("Invalid resource");
+        });
+
+    admissionTestSupport.assertThatThrownBy(admissionController::handle)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid resource");
+  }
+
+  @Test
   void mutatesResource() {
-    AdmissionController<HasMetadata> admissionController =
-        new AdmissionController<>((resource, operation) -> {
+    var admissionController =
+        new AdmissionController<HasMetadata>((resource, operation) -> {
           resource.getMetadata().getLabels().putIfAbsent(AdmissionTestSupport.LABEL_KEY,
               LABEL_TEST_VALUE);
           return resource;
         });
     admissionTestSupport.mutatesResource(admissionController::handle);
+  }
+
+  @Test
+  void mutatesResource_whenNotAllowedException() {
+    var admissionController =
+        new AdmissionController<>((Mutator<HasMetadata>) (resource, operation) -> {
+          throw new NotAllowedException(MISSING_REQUIRED_LABEL);
+        });
+
+    admissionTestSupport.notAllowedException(admissionController::handle);
+  }
+
+  @Test
+  void mutatesResource_whenOtherException() {
+    var admissionController =
+        new AdmissionController<>((Mutator<HasMetadata>) (resource, operation) -> {
+          throw new IllegalArgumentException("Invalid resource");
+        });
+
+    admissionTestSupport.assertThatThrownBy(admissionController::handle)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid resource");
   }
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/admission/AdmissionTestSupport.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/admission/AdmissionTestSupport.java
@@ -1,7 +1,6 @@
 package io.javaoperatorsdk.webhook.admission;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Base64;
 import java.util.UUID;
 import java.util.function.Function;
@@ -20,14 +19,13 @@ public class AdmissionTestSupport {
   public static final String LABEL_TEST_VALUE = "mutation-test";
 
   public static AdmissionReview createTestAdmissionReview() {
-    AdmissionReview admissionReview = new AdmissionReview();
-    AdmissionRequest request = new AdmissionRequest();
+    var admissionReview = new AdmissionReview();
+    var request = new AdmissionRequest();
     admissionReview.setRequest(request);
     request.setOperation(Operation.CREATE.name());
     request.setUid(UUID.randomUUID().toString());
-    Deployment deployment = null;
-    try (InputStream is = AdmissionTestSupport.class.getResourceAsStream("deployment.yaml")) {
-      deployment = Serialization.unmarshal(is, Deployment.class);
+    try (var is = AdmissionTestSupport.class.getResourceAsStream("deployment.yaml")) {
+      var deployment = Serialization.unmarshal(is, Deployment.class);
       request.setObject(deployment);
     } catch (IOException e) {
       throw new IllegalStateException(e);
@@ -35,11 +33,8 @@ public class AdmissionTestSupport {
     return admissionReview;
   }
 
-
-
   void validatesResource(Function<AdmissionReview, AdmissionReview> function) {
     var inputAdmissionReview = createTestAdmissionReview();
-
     var admissionReview = function.apply(inputAdmissionReview);
 
     assertThat(admissionReview.getResponse().getUid())
@@ -52,14 +47,12 @@ public class AdmissionTestSupport {
 
   void mutatesResource(Function<AdmissionReview, AdmissionReview> function) {
     var inputAdmissionReview = createTestAdmissionReview();
-
     var admissionReview = function.apply(inputAdmissionReview);
 
     assertThat(admissionReview.getResponse().getAllowed()).isTrue();
-    String patch = new String(Base64.getDecoder().decode(admissionReview.getResponse().getPatch()));
-    assertThat(patch)
-        .isEqualTo(
-            "[{\"op\":\"add\",\"path\":\"/metadata/labels/app.kubernetes.io~1name\",\"value\":\"mutation-test\"}]");
+    var patch = new String(Base64.getDecoder().decode(admissionReview.getResponse().getPatch()));
+    assertThat(patch).isEqualTo(
+        "[{\"op\":\"add\",\"path\":\"/metadata/labels/app.kubernetes.io~1name\",\"value\":\"mutation-test\"}]");
   }
 
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionControllerTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionControllerTest.java
@@ -1,38 +1,75 @@
 package io.javaoperatorsdk.webhook.admission;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.javaoperatorsdk.webhook.admission.mutation.AsyncMutator;
+import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
+import io.javaoperatorsdk.webhook.admission.validation.Validator;
 
-import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.*;
+import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.LABEL_KEY;
+import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.LABEL_TEST_VALUE;
+import static io.javaoperatorsdk.webhook.admission.AdmissionTestSupport.MISSING_REQUIRED_LABEL;
 
 class AsyncAdmissionControllerTest {
 
   AdmissionTestSupport admissionTestSupport = new AdmissionTestSupport();
 
   @Test
-  void validatesResource() throws ExecutionException, InterruptedException {
-    AsyncAdmissionController<HasMetadata> admissionController =
-        new AsyncAdmissionController<>((resource, operation) -> {
-          if (resource.getMetadata().getLabels().get(LABEL_KEY) == null) {
-            throw new NotAllowedException(MISSING_REQUIRED_LABEL);
-          }
-        });
-
+  void validatesResource() {
+    var admissionController = new AsyncAdmissionController<HasMetadata>((resource, operation) -> {
+    });
 
     admissionTestSupport
         .validatesResource(res -> admissionController.handle(res).toCompletableFuture().join());
-
-
   }
 
   @Test
-  void mutatesResource() throws ExecutionException, InterruptedException {
-    AsyncAdmissionController<HasMetadata> admissionController =
+  void validatesResource_whenNotAllowedException() {
+    var admissionController =
+        new AsyncAdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
+          throw new NotAllowedException(MISSING_REQUIRED_LABEL);
+        });
+
+    admissionTestSupport
+        .notAllowedException(res -> admissionController.handle(res).toCompletableFuture().join());
+  }
+
+  @Test
+  void validatesResource_whenOtherException() {
+    var admissionController =
+        new AsyncAdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
+          throw new IllegalArgumentException("Invalid resource");
+        });
+
+    admissionTestSupport.assertThatThrownBy(
+        res -> admissionController.handle(res).toCompletableFuture()
+            .join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage("Invalid resource");
+  }
+
+  @Test
+  void mutatesResource_withMutator() {
+    var admissionController =
+        new AsyncAdmissionController<>((Mutator<HasMetadata>) (resource,
+            operation) -> {
+          resource.getMetadata().getLabels().putIfAbsent(LABEL_KEY, LABEL_TEST_VALUE);
+          return resource;
+        });
+
+    admissionTestSupport
+        .mutatesResource(res -> admissionController.handle(res).toCompletableFuture().join());
+  }
+
+  @Test
+  void mutatesResource_withAsyncMutator() {
+    var admissionController =
         new AsyncAdmissionController<>((AsyncMutator<HasMetadata>) (resource,
             operation) -> CompletableFuture.supplyAsync(() -> {
               resource.getMetadata().getLabels().putIfAbsent(LABEL_KEY, LABEL_TEST_VALUE);
@@ -43,4 +80,61 @@ class AsyncAdmissionControllerTest {
         .mutatesResource(res -> admissionController.handle(res).toCompletableFuture().join());
   }
 
+  @Test
+  void mutatesResource_withMutator_whenNotAllowedException() {
+    var admissionController =
+        new AsyncAdmissionController<>((Mutator<HasMetadata>) (resource,
+            operation) -> {
+          throw new NotAllowedException(MISSING_REQUIRED_LABEL);
+        });
+
+    admissionTestSupport.notAllowedException(
+        res -> admissionController.handle(res).toCompletableFuture().join());
+  }
+
+  @Test
+  void mutatesResource_withAsyncMutator_whenNotAllowedException() {
+    var admissionController =
+        new AsyncAdmissionController<>((AsyncMutator<HasMetadata>) (resource,
+            operation) -> CompletableFuture.supplyAsync(() -> {
+              throw new NotAllowedException(MISSING_REQUIRED_LABEL);
+            }));
+
+    admissionTestSupport.notAllowedException(
+        res -> admissionController.handle(res).toCompletableFuture().join());
+  }
+
+  @Test
+  void mutatesResource_withMutator_whenOtherException() {
+    var admissionController =
+        new AsyncAdmissionController<>((Mutator<HasMetadata>) (resource,
+            operation) -> {
+          throw new IllegalArgumentException("Invalid resource");
+        });
+
+    admissionTestSupport.assertThatThrownBy(
+        res -> admissionController.handle(res).toCompletableFuture()
+            .join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage("Invalid resource");
+  }
+
+  @Test
+  void mutatesResource_withAsyncMutator_whenOtherException() {
+    var admissionController =
+        new AsyncAdmissionController<>((AsyncMutator<HasMetadata>) (resource,
+            operation) -> CompletableFuture.supplyAsync(() -> {
+              throw new IllegalArgumentException("Invalid resource");
+            }));
+
+    admissionTestSupport.assertThatThrownBy(
+        res -> admissionController.handle(res).toCompletableFuture()
+            .join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage("Invalid resource");
+  }
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/AsyncConversionControllerTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/AsyncConversionControllerTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionResponse;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionReview;
-import io.javaoperatorsdk.webhook.conversion.mapper.*;
+import io.javaoperatorsdk.webhook.conversion.mapper.AsyncV1Mapper;
+import io.javaoperatorsdk.webhook.conversion.mapper.AsyncV2Mapper;
+import io.javaoperatorsdk.webhook.conversion.mapper.AsyncV3Mapper;
 
 class AsyncConversionControllerTest {
 
@@ -26,7 +28,6 @@ class AsyncConversionControllerTest {
   void handlesSimpleConversion() {
     conversionTestSupport.handlesSimpleConversion(getConversionReviewConversionResponseFunction());
   }
-
 
   @Test
   void convertsVariousVersionsInSingleRequest() {
@@ -49,5 +50,4 @@ class AsyncConversionControllerTest {
       }
     };
   }
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/ConversionControllerTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/ConversionControllerTest.java
@@ -43,5 +43,4 @@ public class ConversionControllerTest {
   private Function<ConversionReview, ConversionResponse> getConversionReviewConversionResponseFunction() {
     return request -> controller.handle(request).getResponse();
   }
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/ConversionTestSupport.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/ConversionTestSupport.java
@@ -1,7 +1,6 @@
 package io.javaoperatorsdk.webhook.conversion;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -11,7 +10,12 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionRequest;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionResponse;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.ConversionReview;
-import io.javaoperatorsdk.webhook.conversion.crd.*;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV1;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV1Spec;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV2;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV2Spec;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3Spec;
 
 import static io.javaoperatorsdk.webhook.conversion.Commons.FAILED_STATUS_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,12 +35,11 @@ public class ConversionTestSupport {
 
   void handlesSimpleConversion(Function<ConversionReview, ConversionResponse> func) {
     var request = createRequest(V2, v1resource());
-
     var response = func.apply(request);
 
     assertThat(response.getConvertedObjects()).hasSize(1);
     assertThat(response.getUid()).isEqualTo(request.getRequest().getUid());
-    CustomResourceV2 convertedObject = (CustomResourceV2) response.getConvertedObjects().get(0);
+    var convertedObject = (CustomResourceV2) response.getConvertedObjects().get(0);
     assertThat(convertedObject.getMetadata()).isEqualTo(v1resource().getMetadata());
     assertThat(convertedObject.getSpec().getAdditionalValue()).isEqualTo(DEFAULT_ADDITIONAL_VALUE);
     assertThat(convertedObject.getSpec().getValue()).isEqualTo(String.valueOf(VALUE));
@@ -44,11 +47,10 @@ public class ConversionTestSupport {
 
   void convertsVariousVersionsInSingleRequest(Function<ConversionReview, ConversionResponse> func) {
     var request = createRequest(V3, v1resource(), v2resource(), v3resource());
-
     var response = func.apply(request);
 
     assertThat(response.getConvertedObjects()).hasSize(3);
-    List<String> namesInOrder = response.getConvertedObjects().stream()
+    var namesInOrder = response.getConvertedObjects().stream()
         .map(HasMetadata.class::cast)
         .map(r -> r.getMetadata().getName()).collect(Collectors.toList());
     assertThat(namesInOrder).containsExactly(V1_NAME, V2_NAME, V3_NAME);
@@ -57,7 +59,6 @@ public class ConversionTestSupport {
 
   void errorResponseOnMissingMapper(Function<ConversionReview, ConversionResponse> func) {
     var request = createRequest("v4", v1resource());
-
     var response = func.apply(request);
 
     assertThat(response.getUid()).isEqualTo(request.getRequest().getUid());
@@ -66,8 +67,8 @@ public class ConversionTestSupport {
   }
 
   public static ConversionReview createRequest(String targetVersion, HasMetadata... resources) {
-    ConversionReview review = new ConversionReview();
-    ConversionRequest request = new ConversionRequest();
+    var review = new ConversionReview();
+    var request = new ConversionRequest();
     request.setDesiredAPIVersion(API_GROUP + "/" + targetVersion);
     request.setUid(UUID.randomUUID().toString());
     request.setObjects(Arrays.asList(resources));
@@ -76,37 +77,35 @@ public class ConversionTestSupport {
   }
 
   public static CustomResourceV1 v1resource() {
-    var r = new CustomResourceV1();
-    r.setMetadata(new ObjectMetaBuilder()
+    var resourceV1 = new CustomResourceV1();
+    resourceV1.setMetadata(new ObjectMetaBuilder()
         .withName(V1_NAME).withNamespace("default")
         .build());
-    r.setSpec(new CustomResourceV1Spec());
-    r.getSpec().setValue(VALUE);
-    return r;
+    resourceV1.setSpec(new CustomResourceV1Spec());
+    resourceV1.getSpec().setValue(VALUE);
+    return resourceV1;
   }
 
   public static CustomResourceV2 v2resource() {
-    var r = new CustomResourceV2();
-    r.setMetadata(new ObjectMetaBuilder()
+    var resourceV2 = new CustomResourceV2();
+    resourceV2.setMetadata(new ObjectMetaBuilder()
         .withName(V2_NAME).withNamespace("default")
         .build());
-    r.setSpec(new CustomResourceV2Spec());
-    r.getSpec().setValue("2");
-    r.getSpec().setAdditionalValue("additionalValueV2");
-    return r;
+    resourceV2.setSpec(new CustomResourceV2Spec());
+    resourceV2.getSpec().setValue("2");
+    resourceV2.getSpec().setAdditionalValue("additionalValueV2");
+    return resourceV2;
   }
 
   public static CustomResourceV3 v3resource() {
-    var r = new CustomResourceV3();
-    r.setMetadata(new ObjectMetaBuilder()
+    var resourceV3 = new CustomResourceV3();
+    resourceV3.setMetadata(new ObjectMetaBuilder()
         .withName(V3_NAME).withNamespace("default")
         .build());
-    r.setSpec(new CustomResourceV3Spec());
-    r.getSpec().setValue("3");
-    r.getSpec().setAdditionalValue("additionalValueV3");
-    r.getSpec().setThirdValue("thirdValue");
-    return r;
+    resourceV3.setSpec(new CustomResourceV3Spec());
+    resourceV3.getSpec().setValue("3");
+    resourceV3.getSpec().setAdditionalValue("additionalValueV3");
+    resourceV3.getSpec().setThirdValue("thirdValue");
+    return resourceV3;
   }
-
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/UtilsTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/UtilsTest.java
@@ -3,7 +3,6 @@ package io.javaoperatorsdk.webhook.conversion;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class UtilsTest {
 

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV1.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV1.java
@@ -15,6 +15,4 @@ public class CustomResourceV1
     extends
     CustomResource<CustomResourceV1Spec, CustomResourceV1Status>
     implements Namespaced {
-
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV1Spec.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV1Spec.java
@@ -12,5 +12,4 @@ public class CustomResourceV1Spec {
     this.value = value;
     return this;
   }
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV1Status.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV1Status.java
@@ -12,5 +12,4 @@ public class CustomResourceV1Status {
     this.value1 = value1;
     return this;
   }
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV2.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV2.java
@@ -15,5 +15,4 @@ public class CustomResourceV2
     extends
     CustomResource<CustomResourceV2Spec, CustomResourceV2Status>
     implements Namespaced {
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV2Status.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV2Status.java
@@ -12,5 +12,4 @@ public class CustomResourceV2Status {
     this.value1 = value1;
     return this;
   }
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV3.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV3.java
@@ -15,5 +15,4 @@ public class CustomResourceV3
     extends
     CustomResource<CustomResourceV3Spec, CustomResourceV3Status>
     implements Namespaced {
-
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV3Spec.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/crd/CustomResourceV3Spec.java
@@ -3,9 +3,7 @@ package io.javaoperatorsdk.webhook.conversion.crd;
 public class CustomResourceV3Spec {
 
   private String value;
-
   private String additionalValue;
-
   private String thirdValue;
 
   public String getValue() {

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/mapper/CustomResourceV1Mapper.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/mapper/CustomResourceV1Mapper.java
@@ -2,7 +2,12 @@ package io.javaoperatorsdk.webhook.conversion.mapper;
 
 import io.javaoperatorsdk.webhook.conversion.Mapper;
 import io.javaoperatorsdk.webhook.conversion.TargetVersion;
-import io.javaoperatorsdk.webhook.conversion.crd.*;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV1;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV1Spec;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV1Status;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3Spec;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3Status;
 
 import static io.javaoperatorsdk.webhook.conversion.ConversionTestSupport.DEFAULT_ADDITIONAL_VALUE;
 import static io.javaoperatorsdk.webhook.conversion.ConversionTestSupport.DEFAULT_THIRD_VALUE;
@@ -12,30 +17,30 @@ public class CustomResourceV1Mapper implements Mapper<CustomResourceV1, CustomRe
 
   @Override
   public CustomResourceV3 toHub(CustomResourceV1 resource) {
-    CustomResourceV3 hub = new CustomResourceV3();
-    hub.setMetadata(resource.getMetadata());
-    var spec = new CustomResourceV3Spec();
-    spec.setValue(Integer.toString(resource.getSpec().getValue()));
-    spec.setAdditionalValue(DEFAULT_ADDITIONAL_VALUE);
-    spec.setThirdValue(DEFAULT_THIRD_VALUE);
-    hub.setSpec(spec);
+    var hubV3 = new CustomResourceV3();
+    hubV3.setMetadata(resource.getMetadata());
+    var specV3 = new CustomResourceV3Spec();
+    specV3.setValue(Integer.toString(resource.getSpec().getValue()));
+    specV3.setAdditionalValue(DEFAULT_ADDITIONAL_VALUE);
+    specV3.setThirdValue(DEFAULT_THIRD_VALUE);
+    hubV3.setSpec(specV3);
     if (resource.getStatus() != null) {
-      hub.setStatus(new CustomResourceV3Status());
-      hub.getStatus().setValue1(resource.getStatus().getValue1());
+      hubV3.setStatus(new CustomResourceV3Status());
+      hubV3.getStatus().setValue1(resource.getStatus().getValue1());
     }
-    return hub;
+    return hubV3;
   }
 
   @Override
   public CustomResourceV1 fromHub(CustomResourceV3 hub) {
-    CustomResourceV1 resource = new CustomResourceV1();
-    resource.setMetadata(hub.getMetadata());
-    resource.setSpec(new CustomResourceV1Spec());
-    resource.getSpec().setValue(Integer.parseInt(hub.getSpec().getValue()));
-    if (resource.getStatus() != null) {
-      resource.setStatus(new CustomResourceV1Status());
-      resource.getStatus().setValue1(hub.getStatus().getValue1());
+    var resourceV1 = new CustomResourceV1();
+    resourceV1.setMetadata(hub.getMetadata());
+    resourceV1.setSpec(new CustomResourceV1Spec());
+    resourceV1.getSpec().setValue(Integer.parseInt(hub.getSpec().getValue()));
+    if (resourceV1.getStatus() != null) {
+      resourceV1.setStatus(new CustomResourceV1Status());
+      resourceV1.getStatus().setValue1(hub.getStatus().getValue1());
     }
-    return resource;
+    return resourceV1;
   }
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/mapper/CustomResourceV2Mapper.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/mapper/CustomResourceV2Mapper.java
@@ -2,7 +2,12 @@ package io.javaoperatorsdk.webhook.conversion.mapper;
 
 import io.javaoperatorsdk.webhook.conversion.Mapper;
 import io.javaoperatorsdk.webhook.conversion.TargetVersion;
-import io.javaoperatorsdk.webhook.conversion.crd.*;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV2;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV2Spec;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV2Status;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3Spec;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3Status;
 
 import static io.javaoperatorsdk.webhook.conversion.ConversionTestSupport.DEFAULT_ADDITIONAL_VALUE;
 import static io.javaoperatorsdk.webhook.conversion.ConversionTestSupport.DEFAULT_THIRD_VALUE;
@@ -12,31 +17,31 @@ public class CustomResourceV2Mapper implements Mapper<CustomResourceV2, CustomRe
 
   @Override
   public CustomResourceV3 toHub(CustomResourceV2 resource) {
-    CustomResourceV3 hub = new CustomResourceV3();
-    hub.setMetadata(resource.getMetadata());
-    var spec = new CustomResourceV3Spec();
-    spec.setValue(resource.getSpec().getValue());
-    spec.setAdditionalValue(DEFAULT_ADDITIONAL_VALUE);
-    spec.setThirdValue(DEFAULT_THIRD_VALUE);
-    hub.setSpec(spec);
+    var hubV3 = new CustomResourceV3();
+    hubV3.setMetadata(resource.getMetadata());
+    var specV3 = new CustomResourceV3Spec();
+    specV3.setValue(resource.getSpec().getValue());
+    specV3.setAdditionalValue(DEFAULT_ADDITIONAL_VALUE);
+    specV3.setThirdValue(DEFAULT_THIRD_VALUE);
+    hubV3.setSpec(specV3);
     if (resource.getStatus() != null) {
-      hub.setStatus(new CustomResourceV3Status());
-      hub.getStatus().setValue1(resource.getStatus().getValue1());
+      hubV3.setStatus(new CustomResourceV3Status());
+      hubV3.getStatus().setValue1(resource.getStatus().getValue1());
     }
-    return hub;
+    return hubV3;
   }
 
   @Override
   public CustomResourceV2 fromHub(CustomResourceV3 hub) {
-    CustomResourceV2 resource = new CustomResourceV2();
-    resource.setMetadata(hub.getMetadata());
-    resource.setSpec(new CustomResourceV2Spec());
-    resource.getSpec().setValue(hub.getSpec().getValue());
-    resource.getSpec().setAdditionalValue(hub.getSpec().getAdditionalValue());
-    if (resource.getStatus() != null) {
-      resource.setStatus(new CustomResourceV2Status());
-      resource.getStatus().setValue1(hub.getStatus().getValue1());
+    var resourceV2 = new CustomResourceV2();
+    resourceV2.setMetadata(hub.getMetadata());
+    resourceV2.setSpec(new CustomResourceV2Spec());
+    resourceV2.getSpec().setValue(hub.getSpec().getValue());
+    resourceV2.getSpec().setAdditionalValue(hub.getSpec().getAdditionalValue());
+    if (resourceV2.getStatus() != null) {
+      resourceV2.setStatus(new CustomResourceV2Status());
+      resourceV2.getStatus().setValue1(hub.getStatus().getValue1());
     }
-    return resource;
+    return resourceV2;
   }
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/conversion/mapper/CustomResourceV3Mapper.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/conversion/mapper/CustomResourceV3Mapper.java
@@ -2,7 +2,7 @@ package io.javaoperatorsdk.webhook.conversion.mapper;
 
 import io.javaoperatorsdk.webhook.conversion.Mapper;
 import io.javaoperatorsdk.webhook.conversion.TargetVersion;
-import io.javaoperatorsdk.webhook.conversion.crd.*;
+import io.javaoperatorsdk.webhook.conversion.crd.CustomResourceV3;
 
 @TargetVersion("v3")
 public class CustomResourceV3Mapper implements Mapper<CustomResourceV3, CustomResourceV3> {

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/ConversionControllers.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/ConversionControllers.java
@@ -19,12 +19,10 @@ public class ConversionControllers {
     return controller;
   }
 
-
   public static AsyncConversionController asyncConversionController() {
     var controller = new AsyncConversionController();
     controller.registerMapper(new AsyncV1Mapper());
     controller.registerMapper(new AsyncV2Mapper());
     return controller;
   }
-
 }

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/customresource/MultiVersionCustomResource.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/customresource/MultiVersionCustomResource.java
@@ -12,5 +12,4 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @ShortNames("tcr")
 public class MultiVersionCustomResource
     extends CustomResource<MultiVersionCustomResourceSpec, Void> {
-
 }

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/customresource/MultiVersionCustomResourceSpecV2.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/customresource/MultiVersionCustomResourceSpecV2.java
@@ -12,5 +12,4 @@ public class MultiVersionCustomResourceSpecV2 {
     this.alteredValue = alteredValue;
     return this;
   }
-
 }

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/mapper/AsyncV1Mapper.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/mapper/AsyncV1Mapper.java
@@ -8,10 +8,9 @@ import io.javaoperatorsdk.webhook.conversion.TargetVersion;
 import io.javaoperatorsdk.webhook.sample.commons.customresource.MultiVersionCustomResource;
 
 @TargetVersion("v1")
-public class AsyncV1Mapper
-    implements AsyncMapper<MultiVersionCustomResource, MultiVersionHub> {
+public class AsyncV1Mapper implements AsyncMapper<MultiVersionCustomResource, MultiVersionHub> {
 
-  private V1Mapper mapper = new V1Mapper();
+  private final V1Mapper mapper = new V1Mapper();
 
   @Override
   public CompletionStage<MultiVersionHub> toHub(MultiVersionCustomResource resource) {
@@ -19,8 +18,7 @@ public class AsyncV1Mapper
   }
 
   @Override
-  public CompletionStage<MultiVersionCustomResource> fromHub(
-      MultiVersionHub hub) {
+  public CompletionStage<MultiVersionCustomResource> fromHub(MultiVersionHub hub) {
     return CompletableFuture.completedStage(mapper.fromHub(hub));
   }
 }

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/mapper/AsyncV2Mapper.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/mapper/AsyncV2Mapper.java
@@ -8,10 +8,9 @@ import io.javaoperatorsdk.webhook.conversion.TargetVersion;
 import io.javaoperatorsdk.webhook.sample.commons.customresource.MultiVersionCustomResourceV2;
 
 @TargetVersion("v2")
-public class AsyncV2Mapper
-    implements AsyncMapper<MultiVersionCustomResourceV2, MultiVersionHub> {
+public class AsyncV2Mapper implements AsyncMapper<MultiVersionCustomResourceV2, MultiVersionHub> {
 
-  private V2Mapper mapper = new V2Mapper();
+  private final V2Mapper mapper = new V2Mapper();
 
   @Override
   public CompletionStage<MultiVersionHub> toHub(MultiVersionCustomResourceV2 resource) {

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/mapper/V2Mapper.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/mapper/V2Mapper.java
@@ -6,8 +6,7 @@ import io.javaoperatorsdk.webhook.sample.commons.customresource.MultiVersionCust
 import io.javaoperatorsdk.webhook.sample.commons.customresource.MultiVersionCustomResourceV2;
 
 @TargetVersion("v2")
-public class V2Mapper
-    implements Mapper<MultiVersionCustomResourceV2, MultiVersionHub> {
+public class V2Mapper implements Mapper<MultiVersionCustomResourceV2, MultiVersionHub> {
 
   @Override
   public MultiVersionHub toHub(MultiVersionCustomResourceV2 resource) {
@@ -18,8 +17,7 @@ public class V2Mapper
   }
 
   @Override
-  public MultiVersionCustomResourceV2 fromHub(
-      MultiVersionHub hub) {
+  public MultiVersionCustomResourceV2 fromHub(MultiVersionHub hub) {
     var res = new MultiVersionCustomResourceV2();
     res.setMetadata(hub.getMetadata());
     res.setSpec(new MultiVersionCustomResourceSpecV2());

--- a/samples/commons/src/test/java/io/javaoperatorsdk/webhook/sample/AbstractEndToEndTest.java
+++ b/samples/commons/src/test/java/io/javaoperatorsdk/webhook/sample/AbstractEndToEndTest.java
@@ -23,7 +23,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("deprecation")
-public class EndToEndTestBase {
+public abstract class AbstractEndToEndTest {
 
   protected KubernetesClient client = new KubernetesClientBuilder().build();
 

--- a/samples/commons/src/test/java/io/javaoperatorsdk/webhook/sample/AbstractEndToEndTest.java
+++ b/samples/commons/src/test/java/io/javaoperatorsdk/webhook/sample/AbstractEndToEndTest.java
@@ -7,7 +7,6 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
-import io.fabric8.kubernetes.api.model.apiextensions.v1.*;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -16,8 +15,9 @@ import io.javaoperatorsdk.webhook.sample.commons.customresource.MultiVersionCust
 import io.javaoperatorsdk.webhook.sample.commons.customresource.MultiVersionCustomResourceV2;
 
 import static io.javaoperatorsdk.webhook.sample.commons.AdmissionControllers.MUTATION_TARGET_LABEL;
-import static io.javaoperatorsdk.webhook.sample.commons.Utils.*;
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.SPIN_UP_GRACE_PERIOD;
+import static io.javaoperatorsdk.webhook.sample.commons.Utils.addRequiredLabels;
+import static io.javaoperatorsdk.webhook.sample.commons.Utils.testIngress;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,9 +57,8 @@ public class EndToEndTestBase {
 
   @Test
   void conversionHook() {
-    await().atMost(Duration.ofSeconds(SPIN_UP_GRACE_PERIOD)).untilAsserted(() -> {
-      avoidRequestTimeout(() -> createV1Resource(TEST_CR_NAME));
-    });
+    await().atMost(Duration.ofSeconds(SPIN_UP_GRACE_PERIOD))
+        .untilAsserted(() -> avoidRequestTimeout(() -> createV1Resource(TEST_CR_NAME)));
     MultiVersionCustomResourceV2 v2 =
         client.resources(MultiVersionCustomResourceV2.class).withName(TEST_CR_NAME).get();
     assertThat(v2.getSpec().getAlteredValue()).isEqualTo("" + CR_SPEC_VALUE);

--- a/samples/commons/src/test/java/io/javaoperatorsdk/webhook/sample/EndToEndTestBase.java
+++ b/samples/commons/src/test/java/io/javaoperatorsdk/webhook/sample/EndToEndTestBase.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@SuppressWarnings("deprecation")
 public class EndToEndTestBase {
 
   protected KubernetesClient client = new KubernetesClientBuilder().build();
@@ -64,6 +65,7 @@ public class EndToEndTestBase {
     assertThat(v2.getSpec().getAlteredValue()).isEqualTo("" + CR_SPEC_VALUE);
   }
 
+  @SuppressWarnings("SameParameterValue")
   private MultiVersionCustomResource createV1Resource(String name) {
     var res = new MultiVersionCustomResource();
     res.setMetadata(new ObjectMetaBuilder()

--- a/samples/quarkus/src/main/java/io/javaoperatorsdk/webhook/sample/conversion/ConversionControllerConfig.java
+++ b/samples/quarkus/src/main/java/io/javaoperatorsdk/webhook/sample/conversion/ConversionControllerConfig.java
@@ -17,5 +17,4 @@ public class ConversionControllerConfig {
   public AsyncConversionController asyncConversionController() {
     return ConversionControllers.asyncConversionController();
   }
-
 }

--- a/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/QuarkusWebhooksE2E.java
+++ b/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/QuarkusWebhooksE2E.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.addConversionHookEndpointToCustomResource;
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.applyAndWait;
 
-class QuarkusWebhooksE2E extends EndToEndTestBase {
+class QuarkusWebhooksE2E extends AbstractEndToEndTest {
 
   @BeforeAll
   static void deployService() throws IOException {

--- a/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/QuarkusWebhooksE2E.java
+++ b/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/QuarkusWebhooksE2E.java
@@ -1,12 +1,10 @@
 package io.javaoperatorsdk.webhook.sample;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.addConversionHookEndpointToCustomResource;
@@ -16,11 +14,10 @@ class QuarkusWebhooksE2E extends EndToEndTestBase {
 
   @BeforeAll
   static void deployService() throws IOException {
-    try (KubernetesClient client = new KubernetesClientBuilder().build();
-        InputStream certManager =
-            new URL(
-                "https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml")
-                .openStream()) {
+    try (var client = new KubernetesClientBuilder().build();
+        var certManager = new URL(
+            "https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml")
+            .openStream()) {
       applyAndWait(client, certManager);
       applyAndWait(client, "target/kubernetes/minikube.yml");
       applyAndWait(client, "k8s/validating-webhook-configuration.yml");

--- a/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/admission/AdmissionEndpointTest.java
+++ b/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/admission/AdmissionEndpointTest.java
@@ -1,7 +1,6 @@
 package io.javaoperatorsdk.webhook.sample.admission;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.http.HttpStatus;
@@ -11,6 +10,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
@@ -89,11 +89,11 @@ class AdmissionEndpointTest {
   }
 
   private String jsonRequest() {
-    try (InputStream is = this.getClass().getResourceAsStream("/admission-request.json")) {
+    try (var is = this.getClass().getResourceAsStream("/admission-request.json")) {
+      assertThat(is).isNotNull();
       return new String(is.readAllBytes(), StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
   }
-
 }

--- a/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/conversion/ConversionEndpointTest.java
+++ b/samples/quarkus/src/test/java/io/javaoperatorsdk/webhook/sample/conversion/ConversionEndpointTest.java
@@ -1,7 +1,6 @@
 package io.javaoperatorsdk.webhook.sample.conversion;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +11,7 @@ import io.restassured.http.ContentType;
 import static io.javaoperatorsdk.webhook.sample.commons.ConversionControllers.ASYNC_CONVERSION_PATH;
 import static io.javaoperatorsdk.webhook.sample.commons.ConversionControllers.CONVERSION_PATH;
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
@@ -66,7 +66,8 @@ class ConversionEndpointTest {
   }
 
   private String request(String path) {
-    try (InputStream is = this.getClass().getResourceAsStream(path)) {
+    try (var is = this.getClass().getResourceAsStream(path)) {
+      assertThat(is).isNotNull();
       return new String(is.readAllBytes(), StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new IllegalStateException(e);

--- a/samples/spring-boot/src/main/java/io/javaoperatorsdk/webhook/sample/springboot/admission/AdmissionEndpoint.java
+++ b/samples/spring-boot/src/main/java/io/javaoperatorsdk/webhook/sample/springboot/admission/AdmissionEndpoint.java
@@ -62,5 +62,4 @@ public class AdmissionEndpoint {
   public Mono<AdmissionReview> asyncValidate(@RequestBody AdmissionReview admissionReview) {
     return Mono.fromCompletionStage(asyncValidatingController.handle(admissionReview));
   }
-
 }

--- a/samples/spring-boot/src/main/java/io/javaoperatorsdk/webhook/sample/springboot/conversion/ConversionConfig.java
+++ b/samples/spring-boot/src/main/java/io/javaoperatorsdk/webhook/sample/springboot/conversion/ConversionConfig.java
@@ -19,5 +19,4 @@ public class ConversionConfig {
   public AsyncConversionController asyncConversionController() {
     return ConversionControllers.asyncConversionController();
   }
-
 }

--- a/samples/spring-boot/src/main/java/io/javaoperatorsdk/webhook/sample/springboot/conversion/ConversionEndpoint.java
+++ b/samples/spring-boot/src/main/java/io/javaoperatorsdk/webhook/sample/springboot/conversion/ConversionEndpoint.java
@@ -37,5 +37,4 @@ public class ConversionEndpoint {
   public Mono<ConversionReview> convertAsync(@RequestBody ConversionReview conversionReview) {
     return Mono.fromCompletionStage(asyncConversionController.handle(conversionReview));
   }
-
 }

--- a/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/SpringBootWebhooksE2E.java
+++ b/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/SpringBootWebhooksE2E.java
@@ -1,14 +1,11 @@
 package io.javaoperatorsdk.webhook.sample.springboot;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.javaoperatorsdk.webhook.sample.EndToEndTestBase;
 
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.addConversionHookEndpointToCustomResource;
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.applyAndWait;
@@ -17,11 +14,10 @@ class SpringBootWebhooksE2E extends EndToEndTestBase {
 
   @BeforeAll
   static void deployService() throws IOException {
-    try (KubernetesClient client = new KubernetesClientBuilder().build();
-        InputStream certManager =
-            new URL(
-                "https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml")
-                .openStream()) {
+    try (var client = new KubernetesClientBuilder().build();
+        var certManager = new URL(
+            "https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml")
+            .openStream()) {
       applyAndWait(client, certManager);
       applyAndWait(client, "target/classes/META-INF/dekorate/kubernetes.yml");
       applyAndWait(client, "k8s/validating-webhook-configuration.yml");

--- a/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/SpringBootWebhooksE2E.java
+++ b/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/SpringBootWebhooksE2E.java
@@ -6,11 +6,12 @@ import java.net.URL;
 import org.junit.jupiter.api.BeforeAll;
 
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.javaoperatorsdk.webhook.sample.AbstractEndToEndTest;
 
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.addConversionHookEndpointToCustomResource;
 import static io.javaoperatorsdk.webhook.sample.commons.Utils.applyAndWait;
 
-class SpringBootWebhooksE2E extends EndToEndTestBase {
+class SpringBootWebhooksE2E extends AbstractEndToEndTest {
 
   @BeforeAll
   static void deployService() throws IOException {

--- a/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/admission/AdmissionAdditionalTestEndpoint.java
+++ b/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/admission/AdmissionAdditionalTestEndpoint.java
@@ -62,5 +62,4 @@ public class AdmissionAdditionalTestEndpoint {
   public Mono<AdmissionReview> errorAsyncValidate(@RequestBody AdmissionReview admissionReview) {
     return Mono.fromCompletionStage(errorAsyncValidatingController.handle(admissionReview));
   }
-
 }

--- a/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/admission/AdmissionEndpointTest.java
+++ b/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/admission/AdmissionEndpointTest.java
@@ -14,8 +14,14 @@ import org.springframework.util.FileCopyUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.BodyInserters;
 
-import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionAdditionalTestEndpoint.*;
-import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionEndpoint.*;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionAdditionalTestEndpoint.ERROR_ASYNC_MUTATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionAdditionalTestEndpoint.ERROR_ASYNC_VALIDATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionAdditionalTestEndpoint.ERROR_MUTATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionAdditionalTestEndpoint.ERROR_VALIDATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionEndpoint.ASYNC_MUTATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionEndpoint.ASYNC_VALIDATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionEndpoint.MUTATE_PATH;
+import static io.javaoperatorsdk.webhook.sample.springboot.admission.AdmissionEndpoint.VALIDATE_PATH;
 
 @Import({AdmissionConfig.class, AdditionalAdmissionConfig.class})
 @WebFluxTest({AdmissionEndpoint.class, AdmissionAdditionalTestEndpoint.class})
@@ -71,7 +77,6 @@ class AdmissionEndpointTest {
         .expectStatus().is5xxServerError();
   }
 
-
   public void testMutate(String path) {
     webClient.post().uri("/" + path).contentType(MediaType.APPLICATION_JSON)
         .body(request())
@@ -89,7 +94,7 @@ class AdmissionEndpointTest {
 
   private BodyInserter<String, ReactiveHttpOutputMessage> request() {
     try {
-      ClassPathResource classPathResource = new ClassPathResource("admission-request.json");
+      var classPathResource = new ClassPathResource("admission-request.json");
       return BodyInserters
           .fromValue(new String(FileCopyUtils.copyToByteArray(classPathResource.getInputStream())));
     } catch (IOException e) {

--- a/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/conversion/ConversionEndpointTest.java
+++ b/samples/spring-boot/src/test/java/io/javaoperatorsdk/webhook/sample/springboot/conversion/ConversionEndpointTest.java
@@ -61,6 +61,7 @@ class ConversionEndpointTest {
         .exchange()
         .expectStatus().isOk().expectBody(ConversionReview.class).consumeWith(res -> {
           var review = res.getResponseBody();
+          assertThat(review).isNotNull();
           var resource1 =
               ((MultiVersionCustomResourceV2) review.getResponse().getConvertedObjects().get(0));
           assertThat(review.getResponse().getConvertedObjects()).hasSize(2);
@@ -78,7 +79,7 @@ class ConversionEndpointTest {
 
   private BodyInserter<String, ReactiveHttpOutputMessage> requestFromResource(String resource) {
     try {
-      ClassPathResource classPathResource = new ClassPathResource(resource);
+      var classPathResource = new ClassPathResource(resource);
       return BodyInserters
           .fromValue(new String(FileCopyUtils.copyToByteArray(classPathResource.getInputStream())));
     } catch (IOException e) {


### PR DESCRIPTION
Fixes #283

* Fixes exception handling in `AsyncDefaultAdmissionRequestMutator`
* Adds convenient `AsyncAdmissionController(Mutator<T> mutator)` constructor
* Shows simplified usage of `Mutator` and `Validator` classes in `io.javaoperatorsdk.webhook.sample.commons.AdmissionControllers`
* Cleanup of code base (I'm already sorry for this one :sweat_smile:)

# Code Coverage

## `main`
![image](https://github.com/user-attachments/assets/49a0cc1c-0a7f-473a-996b-ff9589f84423)

## `bugfix/fix-async-mutator-exception-handling`
![image](https://github.com/user-attachments/assets/f5c48442-f293-4171-be33-5c9d941067db)
