### PR TITLE
Support for passing old resource to validator

### DIFF
--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
@@ -37,6 +37,12 @@ public class AdmissionUtils {
         : admissionRequest.getObject());
   }
 
+  public static KubernetesResource getOldResource(AdmissionRequest admissionRequest,
+      Operation operation) {
+    return (KubernetesResource) (operation == Operation.UPDATE ? admissionRequest.getOldObject()
+        : getTargetResource(admissionRequest, operation));
+  }
+
   public static AdmissionResponse admissionResponseFromMutation(KubernetesResource originalResource,
       KubernetesResource mutatedResource) {
     var admissionResponse = new AdmissionResponse();

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/AdmissionUtils.java
@@ -37,12 +37,6 @@ public class AdmissionUtils {
         : admissionRequest.getObject());
   }
 
-  public static KubernetesResource getOldResource(AdmissionRequest admissionRequest,
-      Operation operation) {
-    return (KubernetesResource) (operation == Operation.UPDATE ? admissionRequest.getOldObject()
-        : getTargetResource(admissionRequest, operation));
-  }
-
   public static AdmissionResponse admissionResponseFromMutation(KubernetesResource originalResource,
       KubernetesResource mutatedResource) {
     var admissionResponse = new AdmissionResponse();

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/AsyncDefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/AsyncDefaultAdmissionRequestValidator.java
@@ -12,8 +12,6 @@ import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.allowedAdmissionResponse;
-import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getOldResource;
-import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getTargetResource;
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.notAllowedExceptionToAdmissionResponse;
 
 public class AsyncDefaultAdmissionRequestValidator<T extends KubernetesResource>
@@ -29,8 +27,8 @@ public class AsyncDefaultAdmissionRequestValidator<T extends KubernetesResource>
   @SuppressWarnings("unchecked")
   public CompletionStage<AdmissionResponse> handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
-    var originalResource = (T) getTargetResource(admissionRequest, operation);
-    var oldResource = (T) getOldResource(admissionRequest, operation);
+    var originalResource = (T) admissionRequest.getObject();
+    var oldResource = (T) admissionRequest.getOldObject();
     var asyncValidate =
         CompletableFuture
             .runAsync(() -> validator.validate(originalResource, oldResource, operation));

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
@@ -8,8 +8,6 @@ import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.allowedAdmissionResponse;
-import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getOldResource;
-import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getTargetResource;
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.notAllowedExceptionToAdmissionResponse;
 
 public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
@@ -25,8 +23,8 @@ public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
   @SuppressWarnings("unchecked")
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
-    var originalResource = (T) getTargetResource(admissionRequest, operation);
-    var oldResource = (T) getOldResource(admissionRequest, operation);
+    var originalResource = (T) admissionRequest.getObject();
+    var oldResource = (T) admissionRequest.getOldObject();
     try {
       validator.validate(originalResource, oldResource, operation);
       return allowedAdmissionResponse();

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/DefaultAdmissionRequestValidator.java
@@ -8,6 +8,7 @@ import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.allowedAdmissionResponse;
+import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getOldResource;
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.getTargetResource;
 import static io.javaoperatorsdk.webhook.admission.AdmissionUtils.notAllowedExceptionToAdmissionResponse;
 
@@ -25,8 +26,9 @@ public class DefaultAdmissionRequestValidator<T extends KubernetesResource>
   public AdmissionResponse handle(AdmissionRequest admissionRequest) {
     var operation = Operation.valueOf(admissionRequest.getOperation());
     var originalResource = (T) getTargetResource(admissionRequest, operation);
+    var oldResource = (T) getOldResource(admissionRequest, operation);
     try {
-      validator.validate(originalResource, operation);
+      validator.validate(originalResource, oldResource, operation);
       return allowedAdmissionResponse();
     } catch (NotAllowedException e) {
       return notAllowedExceptionToAdmissionResponse(e);

--- a/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/Validator.java
+++ b/core/src/main/java/io/javaoperatorsdk/webhook/admission/validation/Validator.java
@@ -6,5 +6,5 @@ import io.javaoperatorsdk.webhook.admission.Operation;
 
 public interface Validator<T extends KubernetesResource> {
 
-  void validate(T resource, Operation operation) throws NotAllowedException;
+  void validate(T resource, T oldResource, Operation operation) throws NotAllowedException;
 }

--- a/core/src/test/java/io/javaoperatorsdk/webhook/admission/AdmissionControllerTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/admission/AdmissionControllerTest.java
@@ -15,15 +15,16 @@ class AdmissionControllerTest {
 
   @Test
   void validatesResource() {
-    var admissionController = new AdmissionController<HasMetadata>((resource, operation) -> {
-    });
+    var admissionController =
+        new AdmissionController<HasMetadata>((resource, oldResource, operation) -> {
+        });
     admissionTestSupport.validatesResource(admissionController::handle);
   }
 
   @Test
   void validatesResource_whenNotAllowedException() {
     var admissionController =
-        new AdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
+        new AdmissionController<>((Validator<HasMetadata>) (resource, oldResource, operation) -> {
           throw new NotAllowedException(MISSING_REQUIRED_LABEL);
         });
     admissionTestSupport.notAllowedException(admissionController::handle);
@@ -32,7 +33,7 @@ class AdmissionControllerTest {
   @Test
   void validatesResource_whenOtherException() {
     var admissionController =
-        new AdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
+        new AdmissionController<>((Validator<HasMetadata>) (resource, oldResource, operation) -> {
           throw new IllegalArgumentException("Invalid resource");
         });
 

--- a/core/src/test/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionControllerTest.java
+++ b/core/src/test/java/io/javaoperatorsdk/webhook/admission/AsyncAdmissionControllerTest.java
@@ -20,8 +20,9 @@ class AsyncAdmissionControllerTest {
 
   @Test
   void validatesResource() {
-    var admissionController = new AsyncAdmissionController<HasMetadata>((resource, operation) -> {
-    });
+    var admissionController =
+        new AsyncAdmissionController<HasMetadata>((resource, oldResource, operation) -> {
+        });
 
     admissionTestSupport
         .validatesResource(res -> admissionController.handle(res).toCompletableFuture().join());
@@ -30,9 +31,10 @@ class AsyncAdmissionControllerTest {
   @Test
   void validatesResource_whenNotAllowedException() {
     var admissionController =
-        new AsyncAdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
-          throw new NotAllowedException(MISSING_REQUIRED_LABEL);
-        });
+        new AsyncAdmissionController<>(
+            (Validator<HasMetadata>) (resource, oldResource, operation) -> {
+              throw new NotAllowedException(MISSING_REQUIRED_LABEL);
+            });
 
     admissionTestSupport
         .notAllowedException(res -> admissionController.handle(res).toCompletableFuture().join());
@@ -41,9 +43,10 @@ class AsyncAdmissionControllerTest {
   @Test
   void validatesResource_whenOtherException() {
     var admissionController =
-        new AsyncAdmissionController<>((Validator<HasMetadata>) (resource, operation) -> {
-          throw new IllegalArgumentException("Invalid resource");
-        });
+        new AsyncAdmissionController<>(
+            (Validator<HasMetadata>) (resource, oldResource, operation) -> {
+              throw new IllegalArgumentException("Invalid resource");
+            });
 
     admissionTestSupport.assertThatThrownBy(
         res -> admissionController.handle(res).toCompletableFuture()

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/AdmissionControllers.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/AdmissionControllers.java
@@ -75,12 +75,16 @@ public class AdmissionControllers {
     @Override
     public void validate(Ingress resource, Ingress oldResource, Operation operation)
         throws NotAllowedException {
+      if (operation.equals(Operation.DELETE)) {
+        return;
+      }
       if (resource.getMetadata().getLabels() == null
           || resource.getMetadata().getLabels().get(VALIDATION_TARGET_LABEL) == null) {
         throw new NotAllowedException("Missing label: " + VALIDATION_TARGET_LABEL);
       }
-      if (!resource.getSpec().getIngressClassName()
-          .equals(oldResource.getSpec().getIngressClassName())) {
+      if (operation.equals(Operation.UPDATE)
+          && !resource.getSpec().getIngressClassName()
+              .equals(oldResource.getSpec().getIngressClassName())) {
         throw new NotAllowedException("IngressClassName cannot be changed");
       }
     }

--- a/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/AdmissionControllers.java
+++ b/samples/commons/src/main/java/io/javaoperatorsdk/webhook/sample/commons/AdmissionControllers.java
@@ -36,7 +36,7 @@ public class AdmissionControllers {
   }
 
   public static AdmissionController<Ingress> errorMutatingController() {
-    return new AdmissionController<>((Validator<Ingress>) (resource, operation) -> {
+    return new AdmissionController<>((Validator<Ingress>) (resource, oldResource, operation) -> {
       throw new IllegalStateException(ERROR_MESSAGE);
     });
   }
@@ -54,9 +54,10 @@ public class AdmissionControllers {
   }
 
   public static AsyncAdmissionController<Ingress> errorAsyncValidatingController() {
-    return new AsyncAdmissionController<>((Validator<Ingress>) (resource, operation) -> {
-      throw new IllegalStateException(ERROR_MESSAGE);
-    });
+    return new AsyncAdmissionController<>(
+        (Validator<Ingress>) (resource, oldResource, operation) -> {
+          throw new IllegalStateException(ERROR_MESSAGE);
+        });
   }
 
   private static class IngressMutator implements Mutator<Ingress> {
@@ -72,10 +73,15 @@ public class AdmissionControllers {
 
   private static class IngressValidator implements Validator<Ingress> {
     @Override
-    public void validate(Ingress resource, Operation operation) throws NotAllowedException {
+    public void validate(Ingress resource, Ingress oldResource, Operation operation)
+        throws NotAllowedException {
       if (resource.getMetadata().getLabels() == null
           || resource.getMetadata().getLabels().get(VALIDATION_TARGET_LABEL) == null) {
         throw new NotAllowedException("Missing label: " + VALIDATION_TARGET_LABEL);
+      }
+      if (!resource.getSpec().getIngressClassName()
+          .equals(oldResource.getSpec().getIngressClassName())) {
+        throw new NotAllowedException("IngressClassName cannot be changed");
       }
     }
   }


### PR DESCRIPTION
Fix https://github.com/operator-framework/josdk-webhooks/issues/329

This is a breaking change since the validator method changed.

The oldResource is never null. It's only different when performing an UPDATE operation

Useful to validate immutable field on the spec